### PR TITLE
ARROW-13530: [C++][Python] Cumulative sum with OptionsWrapper and Python tests

### DIFF
--- a/cpp/src/arrow/compute/kernels/vector_cumulative_ops.cc
+++ b/cpp/src/arrow/compute/kernels/vector_cumulative_ops.cc
@@ -29,6 +29,35 @@
 namespace arrow {
 namespace compute {
 namespace internal {
+namespace {
+template <typename OptionsType>
+struct CumulativeOptionsWrapper : public OptionsWrapper<OptionsType> {
+  using State = CumulativeOptionsWrapper<OptionsType>;
+
+  explicit CumulativeOptionsWrapper(OptionsType options) : OptionsWrapper<OptionsType>(std::move(options)) {}
+
+  static Result<std::unique_ptr<KernelState>> Init(KernelContext* ctx,
+                                                   const KernelInitArgs& args) {
+    auto options = static_cast<const OptionsType*>(args.options);
+    if (!options) {
+      return Status::Invalid(
+          "Attempted to initialize KernelState from null FunctionOptions");
+    }
+
+    const auto& start = options->start;
+    if (!start || !start->is_valid) {
+      return Status::Invalid("Cumulative `start` option must be non-null and valid");
+    }
+
+    // Ensure `start` option matches input type
+    if (!start->type->Equals(args.inputs[0].type)) {
+      ARROW_ASSIGN_OR_RAISE(auto casted_start, Cast(Datum(start), args.inputs[0].type));
+      auto new_options = OptionsType(casted_start.scalar(), options->skip_nulls);
+      return ::arrow::internal::make_unique<State>(new_options);
+    }
+    return ::arrow::internal::make_unique<State>(*options);
+  }
+};
 
 // Base class for all cumulative compute functions. Op can be any binary associative
 // operation (+, *, min, etc.) and OptionsType the options type corresponding to Op.
@@ -41,14 +70,9 @@ struct CumulativeGeneric {
   using ArgValue = typename GetViewType<ArgType>::T;
 
   static Status Exec(KernelContext* ctx, const ExecBatch& batch, Datum* out) {
-    const auto& options = OptionsWrapper<OptionsType>::Get(ctx);
+    const auto& options = CumulativeOptionsWrapper<OptionsType>::Get(ctx);
+    auto start = UnboxScalar<OutType>::Unbox(*(options.start));
     auto skip_nulls = options.skip_nulls;
-
-    auto out_type = batch.GetDescriptors()[0].type;
-    ARROW_ASSIGN_OR_RAISE(
-        auto cast_value,
-        Cast(Datum(options.start), out_type, CastOptions::Safe(), ctx->exec_context()));
-    auto start = UnboxScalar<OutType>::Unbox(*cast_value.scalar());
 
     int64_t base_output_offset = 0;
     bool encountered_null = false;
@@ -148,6 +172,7 @@ const FunctionDoc cumulative_sum_checked_doc{
      "doesn't fail on overflow, use function \"cumulative_sum\"."),
     {"values"},
     "CumulativeSumOptions"};
+}  // namespace
 
 template <typename Op, typename OptionsType>
 void MakeVectorCumulativeFunction(FunctionRegistry* registry, const std::string func_name,
@@ -166,7 +191,7 @@ void MakeVectorCumulativeFunction(FunctionRegistry* registry, const std::string 
     kernel.mem_allocation = MemAllocation::type::PREALLOCATE;
     kernel.signature = KernelSignature::Make({InputType(ty)}, OutputType(ty));
     kernel.exec = ArithmeticExecFromOp<CumulativeGeneric, Op, OptionsType>(ty);
-    kernel.init = OptionsWrapper<OptionsType>::Init;
+    kernel.init = CumulativeOptionsWrapper<OptionsType>::Init;
     DCHECK_OK(func->AddKernel(std::move(kernel)));
   }
 

--- a/python/pyarrow/_compute.pyx
+++ b/python/pyarrow/_compute.pyx
@@ -1739,7 +1739,6 @@ class PartitionNthOptions(_PartitionNthOptions):
 cdef class _CumulativeSumOptions(FunctionOptions):
     def _set_options(self, start, skip_nulls):
         if not isinstance(start, Scalar):
-            # Is it a Python scalar?
             try:
                 start = lib.scalar(start)
             except Exception:
@@ -1755,13 +1754,13 @@ class CumulativeSumOptions(_CumulativeSumOptions):
 
     Parameters
     ----------
-    start : Scalar (optional, default 0.0)
+    start : Scalar, default 0.0
         Starting value for sum computation
-    skip_nulls : bool (optional, default False)
-        When false, propagates the first null/NaN encountered
+    skip_nulls : bool, default False
+        When false, propagates the first null encountered.
     """
 
-    def __init__(self, start=0.0, skip_nulls=False):
+    def __init__(self, start=0.0, *, skip_nulls=False):
         self._set_options(start, skip_nulls)
 
 

--- a/python/pyarrow/_compute.pyx
+++ b/python/pyarrow/_compute.pyx
@@ -1755,13 +1755,13 @@ class CumulativeSumOptions(_CumulativeSumOptions):
 
     Parameters
     ----------
-    start : Scalar (optional, default 0)
+    start : Scalar (optional, default 0.0)
         Starting value for sum computation
     skip_nulls : bool (optional, default False)
         When false, propagates the first null/NaN encountered
     """
 
-    def __init__(self, start=0, skip_nulls=False):
+    def __init__(self, start=0.0, skip_nulls=False):
         self._set_options(start, skip_nulls)
 
 

--- a/python/pyarrow/tests/test_compute.py
+++ b/python/pyarrow/tests/test_compute.py
@@ -2504,6 +2504,63 @@ def test_min_max_element_wise():
     assert result == pa.array([1, 2, None])
 
 
+@pytest.mark.parametrize('start', (1.1, 10.5, -10.5))
+@pytest.mark.parametrize('skip_nulls', (True, False))
+def test_cumulative_sum(start, skip_nulls):
+    # Exact tests (e.g., integral types)
+    start_int = int(start)
+    starts = [start_int, pa.scalar(start_int, type=pa.int8()),
+              pa.scalar(start_int, type=pa.int64())]
+    for strt in starts:
+        arrays = [
+            pa.array([1, 2, 3]),
+            pa.array([0, None, 20, 30]),
+            pa.chunked_array([[0, None], [20, 30]])
+        ]
+        expected_arrays = [
+            pa.array([1, 3, 6]),
+            pa.array([0, None, 20, 50])
+            if skip_nulls else pa.array([0, None, None, None]),
+            pa.chunked_array([[0, None, 20, 50]])
+            if skip_nulls else pa.chunked_array([[0, None, None, None]])
+        ]
+        for i, arr in enumerate(arrays):
+            result = pc.cumulative_sum(arr, start=strt, skip_nulls=skip_nulls)
+            # Add `start` offset to expected array before comparing
+            expected = pc.add(expected_arrays[i], strt)
+            assert result.equals(expected)
+
+    # Approximate and NaN tests (e.g., floating-point types)
+    # NOTE: Conversion from Arrow to NumPy replaces null slots with NaNs
+    # which prevent fully validating both states of `skip_nulls` for
+    # floating-point values. Ideally, equality comparisons make use of Arrow's
+    # `equals()` functions but an approximate version is not exposed in Python.
+    starts = [start, pa.scalar(start, type=pa.float32()),
+              pa.scalar(start, type=pa.float64())]
+    for strt in starts:
+        arrays = [
+            pa.array([1.1, 2.2, 3.3]),
+            pa.array([1, np.nan, 2, -3, 4, 5]),
+            pa.array([1, np.nan, None, 3, None, 5])
+        ]
+        expected_arrays = [
+            np.array([1.1, 3.3, 6.6]),
+            np.array([1, np.nan, np.nan, np.nan, np.nan, np.nan]),
+            np.array([1, np.nan, None, np.nan, None, np.nan])
+            if skip_nulls else np.array([1, np.nan, None, None, None, None])
+        ]
+        for i, arr in enumerate(arrays):
+            result = pc.cumulative_sum(arr, start=strt, skip_nulls=skip_nulls)
+            # Add `start` offset to expected array before comparing
+            expected = pc.add(expected_arrays[i], strt)
+            np.testing.assert_array_almost_equal(result.to_numpy(
+                zero_copy_only=False), expected.to_numpy(zero_copy_only=False))
+
+    for strt in ['a', pa.scalar('arrow'), 1.1]:
+        with pytest.raises(pa.ArrowInvalid):
+            pc.cumulative_sum([1, 2, 3], start=strt)
+
+
 def test_make_struct():
     assert pc.make_struct(1, 'a').as_py() == {'0': 1, '1': 'a'}
 


### PR DESCRIPTION
* Use CumulativeOptionsWrapper to perform options' validation and casting
* Add Python tests for raw and Scalar start values and skip_nulls